### PR TITLE
feat: configurable TTS provider — OpenAI (default) or ElevenLabs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phone-agent
-description: "Run a real-time AI phone agent using Twilio, Deepgram, and ElevenLabs. Handles incoming calls, transcribes audio, generates responses via LLM, and speaks back via streaming TTS. Use when user wants to: (1) Test voice AI capabilities, (2) Handle phone calls programmatically, (3) Build a conversational voice bot."
+description: "Run a real-time AI phone agent using Twilio, Deepgram, and OpenAI/ElevenLabs TTS. Handles incoming calls, transcribes audio, generates responses via LLM, and speaks back via streaming TTS. Use when user wants to: (1) Test voice AI capabilities, (2) Handle phone calls programmatically, (3) Build a conversational voice bot."
 ---
 
 # Phone Agent Skill
@@ -13,15 +13,15 @@ Runs a local FastAPI server that acts as a real-time voice bridge.
 Twilio (Phone) <--> WebSocket (Audio) <--> [Local Server] <--> Deepgram (STT)
                                                   |
                                                   +--> OpenAI (LLM)
-                                                  +--> ElevenLabs (TTS)
+                                                  +--> OpenAI TTS or ElevenLabs (TTS)
 ```
 
 ## Prerequisites
 
 1.  **Twilio Account**: Phone number + TwiML App.
 2.  **Deepgram API Key**: For fast speech-to-text.
-3.  **OpenAI API Key**: For the conversation logic.
-4.  **ElevenLabs API Key**: For realistic text-to-speech.
+3.  **OpenAI API Key**: For conversation logic + TTS (default).
+4.  **ElevenLabs API Key** (optional): For higher-quality TTS (set `TTS_PROVIDER=elevenlabs`).
 5.  **Ngrok** (or similar): To expose your local port 8080 to Twilio.
 
 ## Setup
@@ -35,10 +35,18 @@ Twilio (Phone) <--> WebSocket (Audio) <--> [Local Server] <--> Deepgram (STT)
     ```bash
     export DEEPGRAM_API_KEY="your_key"
     export OPENAI_API_KEY="your_key"
-    export ELEVENLABS_API_KEY="your_key"
     export TWILIO_ACCOUNT_SID="your_sid"
     export TWILIO_AUTH_TOKEN="your_token"
     export PORT=8080
+
+    # TTS Provider (default: openai — ~6x cheaper than ElevenLabs)
+    export TTS_PROVIDER="openai"          # or "elevenlabs"
+    export OPENAI_TTS_VOICE="echo"        # alloy, echo, fable, onyx, nova, shimmer
+    export OPENAI_TTS_MODEL="tts-1"       # tts-1 (fast) or tts-1-hd (quality)
+
+    # Only needed if TTS_PROVIDER=elevenlabs
+    export ELEVENLABS_API_KEY="your_key"
+    export ELEVENLABS_VOICE_ID="onwK4e9ZLuTAKqWW03F9"
     ```
 
     **Optional - System Prompt Customization** (priority: file > env var > built-in):
@@ -77,6 +85,8 @@ Call your Twilio number. The agent should answer, transcribe your speech, think,
 ## Customization
 
 - **System Prompt**: Configure via `SYSTEM_PROMPT_FILE` (load from file), `SYSTEM_PROMPT` (env var), or modify the built-in defaults with `AGENT_NAME` and `OWNER_NAME`.
-- **Voice**: Change `ELEVENLABS_VOICE_ID` to use different voices.
+- **TTS Provider**: Set `TTS_PROVIDER=openai` (default, $0.03/min) or `TTS_PROVIDER=elevenlabs` ($0.17/min, higher quality).
+- **Voice (OpenAI)**: Set `OPENAI_TTS_VOICE` — options: alloy, echo, fable, onyx, nova, shimmer.
+- **Voice (ElevenLabs)**: Change `ELEVENLABS_VOICE_ID` to use different voices.
 - **Model**: Switch `gpt-4o-mini` to `gpt-4` for smarter (but slower) responses.
 - **Language**: Set `AGENT_LANGUAGE` to `en` or `de` for English or German.

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -29,6 +29,11 @@ DEEPGRAM_API_KEY = os.getenv("DEEPGRAM_API_KEY")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
 ELEVENLABS_VOICE_ID = os.getenv("ELEVENLABS_VOICE_ID", "onwK4e9ZLuTAKqWW03F9")  # Daniel - Steady Broadcaster (male)
+
+# TTS Provider: "openai" (default, ~6x cheaper) or "elevenlabs" (higher quality)
+TTS_PROVIDER = os.getenv("TTS_PROVIDER", "openai").lower()
+OPENAI_TTS_VOICE = os.getenv("OPENAI_TTS_VOICE", "echo")  # warm, smooth, conversational
+OPENAI_TTS_MODEL = os.getenv("OPENAI_TTS_MODEL", "tts-1")  # tts-1 for low latency, tts-1-hd for quality
 PUBLIC_URL = os.getenv("PUBLIC_URL")
 BRAVE_API_KEY = os.getenv("BRAVE_API_KEY")  # For web search
 TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID")
@@ -411,7 +416,87 @@ async def web_search(query: str) -> str:
 
 
 async def text_to_speech_stream(text: str):
-    """Stream TTS from ElevenLabs."""
+    """Stream TTS from the configured provider (openai or elevenlabs)."""
+    if TTS_PROVIDER == "elevenlabs":
+        async for chunk in _tts_elevenlabs_stream(text):
+            yield chunk
+    else:
+        async for chunk in _tts_openai_stream(text):
+            yield chunk
+
+
+async def _tts_openai_stream(text: str):
+    """Stream TTS from OpenAI API with ffmpeg transcode to µ-law 8kHz."""
+    url = "https://api.openai.com/v1/audio/speech"
+    headers = {
+        "Authorization": f"Bearer {OPENAI_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    data = {
+        "model": OPENAI_TTS_MODEL,
+        "input": text,
+        "voice": OPENAI_TTS_VOICE,
+        "response_format": "mp3",
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        async with client.stream("POST", url, json=data, headers=headers) as response:
+            if response.status_code != 200:
+                error_body = await response.aread()
+                logger.error(
+                    "OpenAI TTS failed (%s): %s",
+                    response.status_code,
+                    error_body.decode("utf-8", errors="replace").strip(),
+                )
+                return
+
+            # OpenAI streams MP3; transcode to µ-law for Twilio
+            ffmpeg = await asyncio.create_subprocess_exec(
+                "ffmpeg", "-loglevel", "error", "-hide_banner",
+                "-i", "pipe:0",
+                "-f", "mulaw", "-ar", "8000", "-ac", "1",
+                "pipe:1",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            async def feed_ffmpeg():
+                try:
+                    async for chunk in response.aiter_bytes():
+                        if ffmpeg.stdin is None:
+                            break
+                        ffmpeg.stdin.write(chunk)
+                        await ffmpeg.stdin.drain()
+                finally:
+                    if ffmpeg.stdin:
+                        ffmpeg.stdin.close()
+
+            feed_task = asyncio.create_task(feed_ffmpeg())
+            try:
+                while True:
+                    if ffmpeg.stdout is None:
+                        break
+                    out = await ffmpeg.stdout.read(4096)
+                    if not out:
+                        break
+                    yield out
+            finally:
+                await feed_task
+                rc = await ffmpeg.wait()
+                if rc != 0:
+                    err = b""
+                    if ffmpeg.stderr:
+                        err = await ffmpeg.stderr.read()
+                    logger.error(
+                        "ffmpeg decode failed (%s): %s",
+                        rc,
+                        err.decode("utf-8", errors="replace").strip(),
+                    )
+
+
+async def _tts_elevenlabs_stream(text: str):
+    """Stream TTS from ElevenLabs API."""
     url = f"https://api.elevenlabs.io/v1/text-to-speech/{ELEVENLABS_VOICE_ID}/stream?output_format=ulaw_8000"
     headers = {"xi-api-key": ELEVENLABS_API_KEY, "Content-Type": "application/json"}
     data = {"text": text, "model_id": "eleven_multilingual_v2"}
@@ -433,18 +518,9 @@ async def text_to_speech_stream(text: str):
             if "audio/mpeg" in content_type or "audio/mp3" in content_type:
                 # ElevenLabs streaming returns MP3 on this plan; decode to mu-law for Twilio.
                 ffmpeg = await asyncio.create_subprocess_exec(
-                    "ffmpeg",
-                    "-loglevel",
-                    "error",
-                    "-hide_banner",
-                    "-i",
-                    "pipe:0",
-                    "-f",
-                    "mulaw",
-                    "-ar",
-                    "8000",
-                    "-ac",
-                    "1",
+                    "ffmpeg", "-loglevel", "error", "-hide_banner",
+                    "-i", "pipe:0",
+                    "-f", "mulaw", "-ar", "8000", "-ac", "1",
                     "pipe:1",
                     stdin=asyncio.subprocess.PIPE,
                     stdout=asyncio.subprocess.PIPE,
@@ -931,4 +1007,10 @@ async def websocket_endpoint(twilio_ws: WebSocket):
 
 
 if __name__ == "__main__":
+    tts_info = (
+        f"OpenAI ({OPENAI_TTS_MODEL}, voice={OPENAI_TTS_VOICE})"
+        if TTS_PROVIDER != "elevenlabs"
+        else f"ElevenLabs (voice_id={ELEVENLABS_VOICE_ID})"
+    )
+    logger.info("TTS provider: %s", tts_info)
     uvicorn.run(app, host=HOST, port=PORT)

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -50,6 +50,10 @@ if not OPENAI_API_KEY:
     logger.warning("OPENAI_API_KEY not set - AI responses will fail")
 if not DEEPGRAM_API_KEY:
     logger.warning("DEEPGRAM_API_KEY not set - transcription will fail")
+if TTS_PROVIDER == "openai" and not OPENAI_API_KEY:
+    logger.warning("TTS_PROVIDER is 'openai' but OPENAI_API_KEY is not set - OpenAI TTS will fail")
+if TTS_PROVIDER == "elevenlabs" and not ELEVENLABS_API_KEY:
+    logger.warning("TTS_PROVIDER is 'elevenlabs' but ELEVENLABS_API_KEY is not set - ElevenLabs TTS will fail")
 
 # Initialize Twilio client for outbound calls
 twilio_client = None


### PR DESCRIPTION
## Summary

Switches the default TTS provider from ElevenLabs to OpenAI, saving ~6x on cost while keeping ElevenLabs as an option for users who prefer higher quality.

## Changes

- **New env var `TTS_PROVIDER`**: `openai` (default) or `elevenlabs`
- **OpenAI TTS streaming**: Streams MP3 from OpenAI API → ffmpeg transcode to µ-law 8kHz for Twilio
- **New env vars**: `OPENAI_TTS_VOICE` (default: echo), `OPENAI_TTS_MODEL` (default: tts-1)
- **Refactored `text_to_speech_stream()`**: Now dispatches to `_tts_openai_stream()` or `_tts_elevenlabs_stream()`
- **Startup logging**: Logs which TTS provider is active

## Cost Comparison

| Provider | Cost/min | Quality | Latency |
|----------|----------|---------|---------|
| OpenAI tts-1 | ~$0.015 | Good | Low |
| OpenAI tts-1-hd | ~$0.03 | Better | Medium |
| ElevenLabs | ~$0.17 | Best | Low |

## Migration

No breaking changes. Existing `ELEVENLABS_API_KEY` setups keep working — just set `TTS_PROVIDER=elevenlabs` to use it. New installs default to OpenAI (which is already a required key for LLM).

## OpenAI Voices

`alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer` — all work in English and German.